### PR TITLE
Fixed teeth in FluxoniumPocket

### DIFF
--- a/SQDMetal/Comps/Qubits.py
+++ b/SQDMetal/Comps/Qubits.py
@@ -2909,8 +2909,8 @@ class FluxoniumPocket(_FluxoniumPocket):
 
         if teeth_options.make_teeth:  # makes teeth to insert readout resonator. best if pad_radius=0
             tooth_left = draw.rectangle(teeth_options.coupled_pad_width,
-                                        teeth_options.coupled_pad_height*1.1, -teeth_options.coupled_pad_gap/2, -((pad_height*0.9)+((pad_gap+teeth_options.coupled_pad_height)/2)))
-            coupler_pad_round_left = draw.Point(-teeth_options.coupled_pad_gap/2, -(teeth_options.coupled_pad_height + ((pad_height+(pad_gap/2))/1.0))).buffer(
+                                        teeth_options.coupled_pad_height*1.1, -teeth_options.coupled_pad_gap/2, -(pad_height+((pad_gap+teeth_options.coupled_pad_height)/2)-(teeth_options.coupled_pad_height*0.05)))
+            coupler_pad_round_left = draw.Point(-teeth_options.coupled_pad_gap/2, -(teeth_options.coupled_pad_height + pad_height+(pad_gap/2))).buffer(
                 teeth_options.coupled_pad_width / 2,
                 resolution=16,
                 cap_style=CAP_STYLE.round)


### PR DESCRIPTION
finally made it so that the rectangular part of teeth are for sure overlapping with capacitor pads before the union whilst still being the right height